### PR TITLE
fixed typo

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ export default function Home() {
                         </h2>
                     </div>
                     <p className="text-xl lg:text-3xl">
-                        Compete in Abbey Park's first ever Computer Engineering
+                        Compete in Abbey Park&lsquo;s first ever Computer Engineering
                         Competition, submit a creation using an Arduino or any
                         Microcontroller to win prizes!
                     </p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ export default function Home() {
                         </h2>
                     </div>
                     <p className="text-xl lg:text-3xl">
-                        Compete in Abbey Parks first ever Computer Engineering
+                        Compete in Abbey Park's first ever Computer Engineering
                         Competition, submit a creation using an Arduino or any
                         Microcontroller to win prizes!
                     </p>

--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -112,7 +112,7 @@ export default function Rules() {
                         <span className="text-xl lg:text-4xl">
                             You can use anything at your disposal to create your
                             project, we will have components and basic
-                            electircal tools available for use at our club.
+                            electrical tools available for use at our club.
                             Items will be given out on a first come first serve
                             basis.
                         </span>


### PR DESCRIPTION
Fixed electrical being spelled "electircal" and changed "abbey parks" to "abbey park's"