### PR TITLE
Fixed spelling mistake

### DIFF
--- a/src/pages/rules.tsx
+++ b/src/pages/rules.tsx
@@ -100,7 +100,7 @@ export default function Rules() {
                             circuit, a regular electrical circuit, or a
                             microcontroller circuit.{" "}
                             <span className="font-bold text-transparent">
-                                Independant programs are not allowed.
+                                Independent programs are not allowed.
                             </span>
                         </span>
                     </div>


### PR DESCRIPTION
Probably could've crashed the site and exploded github's server rooms if it weren't fixed